### PR TITLE
Determine base_url based on HTTP_HOST to save port

### DIFF
--- a/function.combine.php
+++ b/function.combine.php
@@ -151,7 +151,7 @@ function smarty_function_combine($params, &$smarty)
             return sprintf(
                 "%s://%s%s/",
                 isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https' : 'http',
-                $_SERVER['SERVER_NAME'],
+                $_SERVER['HTTP_HOST'],
                 rtrim(dirname($_SERVER['PHP_SELF']), '/\\')
             );
         }


### PR DESCRIPTION
When loading resources in debug mode, the HTTP_HOST should be used instead of SERVER_NAME. Besides the port issue, SERVER_NAME is the internal name of the host on the server, this can differ from where the user requested the site from. (i.e. SERVER_NAME is myhost.local, but the user requested myhost.com)