### PR TITLE
Fix content duplication bug

### DIFF
--- a/function.combine.php
+++ b/function.combine.php
@@ -84,7 +84,7 @@ function smarty_function_combine($params, &$smarty)
                     mkdir($dirname, 0755, true);
                 }
 
-                $fh = fopen($params['file_path'] . $output_filename, 'a+');
+                $fh = fopen($params['file_path'] . $output_filename, 'w');
 
                 if (flock($fh, LOCK_EX)) {
                     foreach ($filelist as $file) {


### PR DESCRIPTION
Change out file mode from 'a+' to 'w' to prevent writing same content multiple times
on sites with high traffic.