### PR TITLE
calculation patch in css minify

### DIFF
--- a/minify/CSSmin.php
+++ b/minify/CSSmin.php
@@ -766,9 +766,9 @@ class CSSmin
     {
         if (is_string($size)) {
             switch (substr($size, -1)) {
-                case 'M': case 'm': return $size * 1048576;
-                case 'K': case 'k': return $size * 1024;
-                case 'G': case 'g': return $size * 1073741824;
+                case 'M': case 'm': return (int) substr($size, 0, -1) * 1048576;
+                case 'K': case 'k': return (int) substr($size, 0, -1) * 1024;
+                case 'G': case 'g': return (int) substr($size, 0, -1) * 1073741824;
             }
         }
 


### PR DESCRIPTION
CSS minify errors out due to wrong variable type.  String gets converted to an actual int before calculation.