### PR TITLE
Substitute relative url() with absolute url()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 
 {
-    "name": "dead23angel/smarty-combine",
+    "name": "leifnel/smarty-combine",
     "description": "Combine and minify many JS or CSS to one file.",
     "license": "MIT",
     "keywords": [
@@ -9,8 +9,8 @@
     ],
     "authors": [
         {
-            "name": "Gorochov Ivan",
-            "homepage": "https://github.com/dead23angel",
+            "name": "Leif Neland",
+            "homepage": "https://github.com/leifnel",
             "role": "Developer"
         }
     ],

--- a/function.combine.php
+++ b/function.combine.php
@@ -90,10 +90,12 @@ function smarty_function_combine($params, &$smarty)
                     foreach ($filelist as $file) {
                         $min = '';
 
+                        $dirname = dirname(str_replace($_SERVER['DOCUMENT_ROOT'],'',$params['file_path'] . $file['name'])); 
+                                                
                         if ($params['type'] == 'js') {
                             $min = JSMin::minify(file_get_contents($params['file_path'] . $file['name']));
                         } elseif ($params['type'] == 'css') {
-                            $min = CSSMin::minify(file_get_contents($params['file_path'] . $file['name']));
+                            $min = CSSMin::minify(preg_replace('/url\\(((?>["\']?))(?!(\\/|http(s)?:|data:|#))(.*?)\\1\\)/', 'url("' . $dirname . '/$4")', file_get_contents($params['file_path'] . $file['name'])));
                         } else {
                             fputs($fh, PHP_EOL . PHP_EOL . '/* ' . $file['name'] . ' @ ' . date('c', $file['time']) . ' */' . PHP_EOL . PHP_EOL);
                             $min = file_get_contents($params['file_path'] . $file['name']);


### PR DESCRIPTION
Substitute relative url('subdir/image.jpg') with absolute url('/css/subdir/image.jpg')

urls relative to the css-file breaks, because the merged and minified file is served from eg /temp/cache instead of eg /css/subdir

This patch adds the "web-basedir" to relative dirs.

See https://stackoverflow.com/q/69548792/1678652